### PR TITLE
Fix issue where IUUID-adaptation did not have default

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,8 @@ Changelog
 - manage resourcedirectory, because previously all resources were marked as "involved" by
   navigation root
   [mamico]
+- fix issue where IUUID-adaptation did not have default value
+  [datakurre]
 
 
 1.0.0 (2016-01-14)

--- a/src/collective/purgebyid/purge.py
+++ b/src/collective/purgebyid/purge.py
@@ -17,6 +17,6 @@ class UuidPurgePath(object):
         return []
 
     def getAbsolutePaths(self):
-        uuid = IUUID(self.context)
+        uuid = IUUID(self.context, None)
         if uuid:
             yield '/@@purgebyid/%s' % uuid


### PR DESCRIPTION
I had issues purging Archetype based content, because purge was apparently triggered before Archetypes got UUID. Yet, because there was already a condition for UUID being None, this was probably the intended behavior from the beginning.