### PR TITLE
plone.transfromchain vs. pubsuccess

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,7 +3,9 @@ Changelog
 
 1.1.0 (unreleased)
 ------------------
-
+- moved headers mutator from PubSuccess event to plone.transformchain.
+  fix missing header using p.a.caching's ramcache operations #2
+  [mamico]
 - added IIDinvolved adapter for easy implements "involved id" extractors
   [mamico]
 - manage resourcedirectory, because previously all resources were marked as "involved" by

--- a/src/collective/purgebyid/configure.zcml
+++ b/src/collective/purgebyid/configure.zcml
@@ -15,7 +15,9 @@
   <adapter factory=".adapter.resourceDirectoryAdapter" />
   <adapter factory=".adapter.resourceRegistryAdapter" />
 
-  <subscriber handler=".events.handle_request_success" />
+  <!-- Mutator: plone.transformchain order 11000 -->
+  <adapter factory=".events.MutatorTransform" name="collective.purgebyid.mutator" />
+
   <subscriber handler=".events.handle_request_after_traversal" />
 
 </configure>


### PR DESCRIPTION
moved headers mutator from PubSuccess event to plone.transformchain.

fix missing header when using p.a.caching's ramcache operations