### PR TITLE
collective.xkey backports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         # -*- Extra requirements: -*-
         "plone.uuid",
     ],
-    extras_require={"test": ["plone.app.testing", "plone.api"]},
+    extras_require={"test": ["plone.app.testing", "plone.api", "plone.app.contenttypes"]},
     entry_points="""
       # -*- Entry points: -*-
       [z3c.autoinclude.plugin]

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         # -*- Extra requirements: -*-
         "plone.uuid",
     ],
-    extras_require={"test": ["plone.app.testing"]},
+    extras_require={"test": ["plone.app.testing", "plone.api"]},
     entry_points="""
       # -*- Entry points: -*-
       [z3c.autoinclude.plugin]

--- a/src/collective/purgebyid/__init__.py
+++ b/src/collective/purgebyid/__init__.py
@@ -1,4 +1,7 @@
-# -*- extra stuff goes here -*-
+import logging
+
+
+logger = logging.getLogger("collective.purgebyid")
 
 
 def initialize(context):

--- a/src/collective/purgebyid/adapter.py
+++ b/src/collective/purgebyid/adapter.py
@@ -13,9 +13,7 @@ import pkg_resources
 
 try:
     pkg_resources.get_distribution("Products.ResourceRegistries")
-    from Products.ResourceRegistries.interfaces import (
-        IResourceRegistry,
-    )  # pragma: nocover
+    from Products.ResourceRegistries.interfaces import IResourceRegistry  # pragma: nocover
 except pkg_resources.DistributionNotFound:
     HAS_RESOURCEREGISTRY = False
 else:

--- a/src/collective/purgebyid/adapter.py
+++ b/src/collective/purgebyid/adapter.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from Acquisition import aq_base
-from collective.purgebyid.api import NOID
 from collective.purgebyid.interfaces import IInvolvedID
 from plone.resource.interfaces import IResourceDirectory
 from plone.uuid.interfaces import IUUID
@@ -25,8 +24,8 @@ else:
 
 @adapter(Interface)
 @implementer(IInvolvedID)
-def contentAdapter(obj):
-    """return uid for context.
+def content_adapter(obj):
+    """return [uid] for context.
 
     * the object is a string
     * the object implements IUUID
@@ -35,7 +34,7 @@ def contentAdapter(obj):
     """
     uuid = None
     if isinstance(obj, str):
-        return obj
+        return [obj]
     obj = aq_base(obj)
     uuid = IUUID(obj, None)
     if uuid is None:
@@ -45,24 +44,24 @@ def contentAdapter(obj):
                 uuid = uuid()
             if not isinstance(uuid, str):
                 uuid = None
-    return uuid
+    return [uuid] if uuid else []
 
 
 @adapter(IResourceDirectory)
 @implementer(IInvolvedID)
-def resourceDirectoryAdapter(context):
+def resource_directory_adapter(context):
     if hasattr(context, "directory"):
         # file system resources
-        return hashlib.sha1(context.directory.encode("utf-8")).hexdigest()  # nosec
+        return [hashlib.sha1(context.directory.encode("utf-8")).hexdigest()]  # nosec
     else:
         # ZODB persistent resources
-        return NOID
+        return []
 
 
 if HAS_RESOURCEREGISTRY:
 
     @adapter(IResourceRegistry)
     @implementer(IInvolvedID)
-    def resourceRegistryAdapter(context):
+    def resource_registry_adapter(context):
         """portal_javascript, portal_css, ..."""
-        return NOID
+        return []

--- a/src/collective/purgebyid/api.py
+++ b/src/collective/purgebyid/api.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from collective.purgebyid.interfaces import IInvolvedID
 from collective.purgebyid import logger
+from collective.purgebyid.interfaces import IInvolvedID
 from past.builtins import basestring
 from zope.annotation.interfaces import IAnnotations
 

--- a/src/collective/purgebyid/api.py
+++ b/src/collective/purgebyid/api.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 from collective.purgebyid.interfaces import IInvolvedID
+from collective.purgebyid import logger
 from past.builtins import basestring
 from zope.annotation.interfaces import IAnnotations
-
-import logging
 
 
 KEY = "collective.purgebyid.involved"
 NOID = object()
-logger = logging.getLogger("collective.purgebyid")
 
 
 def getInvolvedObjs(request):
@@ -32,12 +30,12 @@ def mark_involved_objects(request, objs, stoponfirst=False):
         else:
             ids = IInvolvedID(obj, None)
         if ids:
-            if ids is NOID:
+            if ids is NOID:  # pragma: nocover
                 logger.warning(
                     "deprecated: the IInvolvedID adapter must return a list of ids"
                 )
                 ids = []
-            if isinstance(ids, basestring):
+            if isinstance(ids, basestring):  # pragma: nocover
                 logger.warning(
                     "deprecated: the IInvolvedID adapter must return a list of ids"
                 )
@@ -56,7 +54,7 @@ def mark_involved(request, id):
     :type single_id: basestring
     """
     logger.debug("mark request %r with %s", request, id)
-    if id is NOID:
+    if id is NOID:  # pragma: nocover
         return
     annotations = IAnnotations(request)
     if annotations.get(KEY, None):

--- a/src/collective/purgebyid/browser.py
+++ b/src/collective/purgebyid/browser.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from collective.purgebyid.api import mark_involved_objects
+from Products.Five.browser import BrowserView
+
+
+class MarkInvolvedView(BrowserView):
+    """Useful utility view to mark IDs in page templates.
+
+    In offers two ways for using it:
+
+    1. marking objects (with UUID)
+
+        tal:define="purgebyid nocall:context/@@purgebyid"
+        ...
+        <tal:mark-involved tal:define="python:purgebyid.mark(image1)" />
+        <tal:mark-involved tal:define="python:purgebyid.mark(image2)" />
+        <tal:mark-involved tal:define="python:purgebyid.mark(image3, image4)" />
+        <tal:mark-involved tal:define="python:purgebyid.mark(*images)" />
+
+    2. marking arbitrary IDs
+
+        tal:define="purgebyid nocall:image/@@purgebyid"
+        ...
+        <tal:mark-involved tal:define="python:purgebyid.mark('0b05ba53734965c6e48bdcd2c7c7e41f')" />
+    """
+
+    def mark(self, *args):
+        """Mark an ID as being involved for delivering the current request"""
+        mark_involved_objects(self.request, args)

--- a/src/collective/purgebyid/configure.zcml
+++ b/src/collective/purgebyid/configure.zcml
@@ -2,6 +2,7 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:five="http://namespaces.zope.org/five"
     xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:zcml="http://namespaces.zope.org/zcml"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     i18n_domain="collective.purgebyid">
@@ -10,13 +11,20 @@
 
   <adapter factory=".purge.UuidPurgePath" name="collective.purgebyid.uuid" />
 
-  <adapter factory=".adapter.contentAdapter" />
-  <adapter factory=".adapter.resourceDirectoryAdapter" />
-  <adapter zcml:condition="installed Products.ResourceRegistry" factory=".adapter.resourceRegistryAdapter" />
+  <adapter factory=".adapter.content_adapter" />
+  <adapter factory=".adapter.resource_directory_adapter" />
+  <adapter zcml:condition="installed Products.ResourceRegistry" factory=".adapter.resource_registry_adapter" />
 
   <!-- Mutator: plone.transformchain order 11000 -->
   <adapter factory=".events.MutatorTransform" name="collective.purgebyid.mutator" />
 
   <subscriber handler=".events.handle_request_after_traversal" />
+
+  <!-- Utility browser view @@purgebyid -->
+  <browser:page for = "*"
+    name = "purgebyid"
+    class = ".browser.MarkInvolvedView"
+    permission = "zope2.View"
+    />
 
 </configure>

--- a/src/collective/purgebyid/events.py
+++ b/src/collective/purgebyid/events.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from collective.purgebyid import logger
 from collective.purgebyid.api import getInvolvedObjs
-from collective.purgebyid.api import markInvolvedObjs
+from collective.purgebyid.api import mark_involved_objects
 from plone.transformchain.interfaces import ITransform
 from ZODB.POSException import ConflictError
 from zope.component import adapter
@@ -60,14 +60,14 @@ class MutatorTransform(object):
 def handle_request_after_traversal(event):
     """handle "IPubAfterTraversal"."""
     try:
-        markInvolvedObjs(
+        mark_involved_objects(
             event.request, event.request.get("PARENTS", []), stoponfirst=True
         )
         # published = event.request.get('PUBLISHED', None)
         # if published:
         #     context = getattr(published, 'context', None)
         #     if context:
-        #         markInvolvedObjs(event.request, [context, ])
+        #         mark_involved_objects(event.request, [context, ])
     except ConflictError:  # pragma: nocover
         raise
     except Exception:  # pragma: nocover

--- a/src/collective/purgebyid/events.py
+++ b/src/collective/purgebyid/events.py
@@ -62,11 +62,7 @@ class MutatorTransform(object):
 
 @adapter(IPubAfterTraversal)
 def handle_request_after_traversal(event):
-    """handle "IPubAfterTraversal".
-
-    TODO: all the objects traversed are involved or only the last (the
-          firstest within request.PARENTS)?
-    """
+    """handle "IPubAfterTraversal"."""
     try:
         markInvolvedObjs(
             event.request, event.request.get("PARENTS", []), stoponfirst=True

--- a/src/collective/purgebyid/events.py
+++ b/src/collective/purgebyid/events.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
+from collective.purgebyid import logger
 from collective.purgebyid.api import getInvolvedObjs
 from collective.purgebyid.api import markInvolvedObjs
-from collective.purgebyid import logger
 from plone.transformchain.interfaces import ITransform
 from ZODB.POSException import ConflictError
 from zope.component import adapter

--- a/src/collective/purgebyid/events.py
+++ b/src/collective/purgebyid/events.py
@@ -1,17 +1,13 @@
 # -*- coding: utf-8 -*-
 from collective.purgebyid.api import getInvolvedObjs
 from collective.purgebyid.api import markInvolvedObjs
+from collective.purgebyid import logger
 from plone.transformchain.interfaces import ITransform
 from ZODB.POSException import ConflictError
 from zope.component import adapter
 from zope.interface import implementer
 from zope.interface import Interface
 from ZPublisher.interfaces import IPubAfterTraversal
-
-import logging
-
-
-logger = logging.getLogger("collective.purgebyid")
 
 
 @implementer(ITransform)

--- a/src/collective/purgebyid/interfaces.py
+++ b/src/collective/purgebyid/interfaces.py
@@ -2,13 +2,11 @@ from zope.interface import Interface
 
 
 class IInvolvedID(Interface):
-    """Adapter to find uid involved for the context.
+    """Adapter to find uids involved for the context."""
 
-    the adapter return:
-    * an id (basestring) or
-    * collective.purgebyid.api.NOID (no id for this
-      object, used for stoponfirst) or
-    * None (no id for this object, try the next) or
-    * a list of element above.
+    def __call__():
+        """Return the involved ids.
 
-    """
+        :returns: involved ids
+        :rtype: list
+        """

--- a/src/collective/purgebyid/testing.py
+++ b/src/collective/purgebyid/testing.py
@@ -1,24 +1,25 @@
+import collective.purgebyid
+import plone.app.contenttypes
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
+from plone.app.testing import applyProfile
 from plone.app.testing import PloneSandboxLayer
 from plone.testing import z2
-from zope.configuration import xmlconfig
 
 
 class CollectivepurgebyidLayer(PloneSandboxLayer):
 
-    defaultBases = (PLONE_FIXTURE,)
+    defaultBases = (PLONE_FIXTURE, )
 
     def setUpZope(self, app, configurationContext):
-        # Load ZCML
-        import collective.purgebyid
-
-        xmlconfig.file(
-            "configure.zcml", collective.purgebyid, context=configurationContext
-        )
+        # Install products that use an old-style initialize() function
+        z2.installProduct(app, 'Products.DateRecurringIndex')
+        self.loadZCML(package=plone.app.contenttypes)
+        self.loadZCML(package=collective.purgebyid)
 
     def setUpPloneSite(self, portal):
+        applyProfile(portal, "plone.app.contenttypes:default")
         portal["portal_workflow"].setDefaultChain("simple_publication_workflow")
 
 

--- a/src/collective/purgebyid/testing.py
+++ b/src/collective/purgebyid/testing.py
@@ -18,6 +18,9 @@ class CollectivepurgebyidLayer(PloneSandboxLayer):
             "configure.zcml", collective.purgebyid, context=configurationContext
         )
 
+    def setUpPloneSite(self, portal):
+        portal["portal_workflow"].setDefaultChain("simple_publication_workflow")
+
 
 COLLECTIVE_PURGEBYID_FIXTURE = CollectivepurgebyidLayer()
 COLLECTIVE_PURGEBYID_INTEGRATION_TESTING = IntegrationTesting(

--- a/src/collective/purgebyid/tests/document_with_dependencies.pt
+++ b/src/collective/purgebyid/tests/document_with_dependencies.pt
@@ -1,0 +1,14 @@
+<html>
+    <head>
+        <title>Document view with</title>
+    </head>
+    <body tal:define="purgebyid nocall:context/@@purgebyid">
+
+        Document
+
+        <!-- Arbitrary dependencies -->
+        <tal:mark-involved tal:define="dummy python:purgebyid.mark('custom-tag-from-template')" />
+        <tal:mark-involved tal:define="dummy python:purgebyid.mark(view.auxiliary_document2)" />
+
+    </body>
+</html>

--- a/src/collective/purgebyid/tests/test_purge.py
+++ b/src/collective/purgebyid/tests/test_purge.py
@@ -1,106 +1,163 @@
 # -*- coding: utf-8 -*-
-from Acquisition import aq_base
-from Acquisition import Explicit
+from collective.purgebyid.api import mark_involved
+from collective.purgebyid.api import mark_involved_objects
+from collective.purgebyid.interfaces import IInvolvedID
 from collective.purgebyid.purge import UuidPurgePath
-from collective.purgebyid.testing import COLLECTIVE_PURGEBYID_INTEGRATION_TESTING
-from plone.transformchain.zpublisher import applyTransformOnSuccess
-from plone.uuid.interfaces import IAttributeUUID
+from collective.purgebyid.testing import COLLECTIVE_PURGEBYID_FUNCTIONAL_TESTING
+from plone import api
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.testing.z2 import Browser
 from plone.uuid.interfaces import IUUID
-from Products.CMFCore.interfaces import IContentish
-from zope.annotation.interfaces import IAnnotations
-from zope.event import notify
-
-# from zope.globalrequest import getRequest
+from Products.Five.browser import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from zope.component import adapter
+from zope.component import getGlobalSiteManager
+from zope.component import provideAdapter
+from zope.globalrequest import setRequest
+from zope.interface import alsoProvides
 from zope.interface import implementer
-from zope.lifecycleevent import ObjectCreatedEvent
-from ZPublisher.pubevents import PubAfterTraversal
+from zope.interface import Interface
+from zope.publisher.interfaces.browser import IBrowserView
+from zope.publisher.interfaces.browser import IHTTPRequest
 
+import transaction
 import unittest
 
 
-@implementer(IContentish)
-class FauxNonContent(Explicit):
-    def __init__(self, name=None):
-        self.__name__ = name
-        self.__parent__ = None  # may be overridden by acquisition
-
-    def getId(self):
-        return self.__name__
-
-    def virtual_url_path(self):
-        parent = aq_base(self.__parent__)
-        if parent is not None:
-            return parent.virtual_url_path() + "/" + self.__name__
-        else:
-            return self.__name__
-
-    def getPhysicalPath(self):
-        return ("",)
-
-    def getParentNode(self):
-        return FauxNonContent("folder")
-
-
-@implementer(IAttributeUUID)
-class FauxContent(FauxNonContent):
-    portal_type = "testtype"
-
-
-class FauxResponse(object):
-    def __init__(self, body="", headers={}):
-        self._body = body
-        self.headers = headers
-
-    def getBody(self):
-        return self._body
-
-    def setBody(self, body):
-        self._body = body
-
-    def getHeader(self, name):
-        return self.headers.get(name)
-
-    def setHeader(self, name, value):
-        self.headers[name] = value
-
-
-@implementer(IAnnotations)
-class FauxRequest(dict):
-    def __init__(self, published, response=None):
-        if response is None:
-            response = FauxResponse("<html/>")
-
-        self["PUBLISHED"] = published
-        self["PARENTS"] = [published]
-        self.response = response
-        self.environ = {}
-
-
-class FauxPubEvent(object):
-    def __init__(self, request):
-        self.request = request
+class MarkerInterface(Interface):
+    """A marker interface"""
 
 
 class TestContentPurge(unittest.TestCase):
 
-    layer = COLLECTIVE_PURGEBYID_INTEGRATION_TESTING
+    layer = COLLECTIVE_PURGEBYID_FUNCTIONAL_TESTING
 
-    def test_publish_content(self):
-        context = FauxContent("foo")
-        notify(ObjectCreatedEvent(context))
-        request = FauxRequest(context)
-        notify(PubAfterTraversal(request))
-        applyTransformOnSuccess(FauxPubEvent(request))
-        self.assertEqual(
-            "#{}#".format(IUUID(context)), request.response.getHeader("X-Ids-Involved")
+    def setUp(self):
+        self.app = self.layer["app"]
+        self.portal = self.layer["portal"]
+        setRequest(self.portal.REQUEST)
+        setRoles(self.portal, TEST_USER_ID, ("Manager",))
+
+    def test_header_published(self):
+        """Test if the headers are published."""
+        # setRoles(self.portal, TEST_USER_ID, ("Manager",))
+        document = api.content.create(
+            title="Document", id="document", type="Document", container=self.portal
+        )
+        api.content.transition(document, to_state="published")
+        transaction.commit()
+        browser = Browser(self.app)
+        browser.open(document.absolute_url())
+        self.assertTrue("X-Ids-Involved" in browser.headers)
+        uuid = IUUID(document)
+        self.assertEqual("#{}#".format(uuid), browser.headers["X-Ids-Involved"])
+
+    def test_involved_adapter(self):
+        """Test if the headers are published."""
+        setRoles(self.portal, TEST_USER_ID, ("Manager",))
+        document = api.content.create(
+            title="Document", id="document", type="Document", container=self.portal
+        )
+        api.content.transition(document, to_state="published")
+        alsoProvides(document, MarkerInterface)
+        transaction.commit()
+
+        # prepare a dummy adapter
+        @adapter(MarkerInterface)
+        @implementer(IInvolvedID)
+        def document_adapter(obj):
+            uuid = IUUID(obj)
+            return [uuid, "custom-tag-from-adapter"]
+
+        provideAdapter(document_adapter)
+
+        browser = Browser(self.app)
+        browser.open(document.absolute_url())
+        self.assertTrue("X-Ids-Involved" in browser.headers)
+        xkey_header = browser.headers["X-Ids-Involved"]
+        self.assertIn(IUUID(document), xkey_header)
+        self.assertIn("custom-tag-from-adapter", xkey_header)
+
+        # cleanup
+        gsm = getGlobalSiteManager()
+        gsm.unregisterAdapter(
+            factory=document_adapter,
+            provided=IInvolvedID,
         )
 
     def test_purge_content(self):
-        context = FauxContent("foo")
-        notify(ObjectCreatedEvent(context))
-        purger = UuidPurgePath(context)
-        list(purger.getAbsolutePaths())
-        self.assertEqual(
-            ["/@@purgebyid/{}".format(IUUID(context))], list(purger.getAbsolutePaths())
+        document = api.content.create(
+            title="Document", id="document", type="Document", container=self.portal
+        )
+        # notify(ObjectCreatedEvent(context))
+        purger = UuidPurgePath(document)
+        self.assertTrue(
+            "/@@purgebyid/{}".format(IUUID(document)) in list(purger.getAbsolutePaths())
         )
         self.assertEqual([], list(purger.getRelativePaths()))
+
+    def test_helper_view(self):
+        document = api.content.create(
+            title="Document", id="document", type="Document", container=self.portal
+        )
+        api.content.transition(document, to_state="published")
+        # create a bunch of auxiliary objects
+        auxiliary_document = api.content.create(
+            title="Auxiliary document",
+            id="auxiliary-document",
+            type="Document",
+            container=self.portal,
+        )
+        api.content.transition(auxiliary_document, to_state="published")
+        auxiliary_document2 = api.content.create(
+            title="Auxiliary document",
+            id="auxiliary-document2",
+            type="Document",
+            container=self.portal,
+        )
+        api.content.transition(auxiliary_document2, to_state="published")
+        transaction.commit()
+
+        # prepare a specialized view
+        @adapter(Interface, IHTTPRequest)
+        class CustomDocumentView(BrowserView):
+            index = ViewPageTemplateFile("document_with_dependencies.pt")
+
+            def __call__(self):
+                self.auxiliary_document = self.context.aq_parent["auxiliary-document"]
+                self.auxiliary_document2 = self.context.aq_parent["auxiliary-document2"]
+                mark_involved_objects(
+                    self.request,
+                    [
+                        self.auxiliary_document,
+                    ],
+                )
+                mark_involved(self.request, "custom-tag-from-view")
+                return self.index()
+
+        # register the view
+        provideAdapter(
+            CustomDocumentView,
+            adapts=(Interface, IHTTPRequest),
+            provides=IBrowserView,
+            name="special-view",
+        )
+        browser = Browser(self.app)
+        browser.open(document.absolute_url() + "/@@special-view")
+
+        self.assertTrue("X-Ids-Involved" in browser.headers)
+        x_ids_header = browser.headers["X-Ids-Involved"]
+        self.assertIn(IUUID(document), x_ids_header)
+        self.assertIn(IUUID(auxiliary_document), x_ids_header)
+        # auxiliary_document2 is marked in the template
+        self.assertIn(IUUID(auxiliary_document2), x_ids_header)
+        self.assertIn("custom-tag-from-view", x_ids_header)
+        self.assertIn("custom-tag-from-template", x_ids_header)
+
+        # cleanup
+        gsm = getGlobalSiteManager()
+        gsm.unregisterAdapter(
+            factory=CustomDocumentView,
+            provided=IBrowserView,
+        )

--- a/src/collective/purgebyid/tests/test_purge.py
+++ b/src/collective/purgebyid/tests/test_purge.py
@@ -50,8 +50,8 @@ class TestContentPurge(unittest.TestCase):
         browser = Browser(self.app)
         browser.open(document.absolute_url())
         self.assertTrue("X-Ids-Involved" in browser.headers)
-        uuid = IUUID(document)
-        self.assertEqual("#{}#".format(uuid), browser.headers["X-Ids-Involved"])
+        ids = browser.headers["X-Ids-Involved"].strip("#").split("#")
+        self.assertIn(IUUID(document), ids)
 
     def test_involved_adapter(self):
         """Test if the headers are published."""
@@ -75,9 +75,9 @@ class TestContentPurge(unittest.TestCase):
         browser = Browser(self.app)
         browser.open(document.absolute_url())
         self.assertTrue("X-Ids-Involved" in browser.headers)
-        xkey_header = browser.headers["X-Ids-Involved"]
-        self.assertIn(IUUID(document), xkey_header)
-        self.assertIn("custom-tag-from-adapter", xkey_header)
+        ids = browser.headers["X-Ids-Involved"].strip("#").split("#")
+        self.assertIn(IUUID(document), ids)
+        self.assertIn("custom-tag-from-adapter", ids)
 
         # cleanup
         gsm = getGlobalSiteManager()
@@ -162,13 +162,13 @@ class TestHelperView(unittest.TestCase):
         browser.open(self.document.absolute_url() + "/@@special-view")
 
         self.assertTrue("X-Ids-Involved" in browser.headers)
-        x_ids_header = browser.headers["X-Ids-Involved"]
-        self.assertIn(IUUID(self.document), x_ids_header)
-        self.assertIn(IUUID(self.auxiliary_document), x_ids_header)
+        ids = browser.headers["X-Ids-Involved"].strip("#").split("#")
+        self.assertIn(IUUID(self.document), ids)
+        self.assertIn(IUUID(self.auxiliary_document), ids)
         # auxiliary_document2 is marked in the template
-        self.assertIn(IUUID(self.auxiliary_document2), x_ids_header)
-        self.assertIn("custom-tag-from-view", x_ids_header)
-        self.assertIn("custom-tag-from-template", x_ids_header)
+        self.assertIn(IUUID(self.auxiliary_document2), ids)
+        self.assertIn("custom-tag-from-view", ids)
+        self.assertIn("custom-tag-from-template", ids)
 
         # cleanup
         gsm = getGlobalSiteManager()
@@ -198,10 +198,10 @@ class TestHelperView(unittest.TestCase):
         browser.open(self.document.absolute_url() + "/@@special-view")
 
         self.assertTrue("X-Ids-Involved" in browser.headers)
-        x_ids_header = browser.headers["X-Ids-Involved"].strip("#").split("#")
-        self.assertIn(IUUID(self.document), x_ids_header)
-        self.assertIn(IUUID(self.auxiliary_document), x_ids_header)
-        self.assertIn(IUUID(self.auxiliary_document2), x_ids_header)
+        ids = browser.headers["X-Ids-Involved"].strip("#").split("#")
+        self.assertIn(IUUID(self.document), ids)
+        self.assertIn(IUUID(self.auxiliary_document), ids)
+        self.assertIn(IUUID(self.auxiliary_document2), ids)
 
         # cleanup
         gsm = getGlobalSiteManager()

--- a/src/collective/purgebyid/tests/test_purge.py
+++ b/src/collective/purgebyid/tests/test_purge.py
@@ -41,7 +41,7 @@ class TestContentPurge(unittest.TestCase):
 
     def test_header_published(self):
         """Test if the headers are published."""
-        # setRoles(self.portal, TEST_USER_ID, ("Manager",))
+        setRoles(self.portal, TEST_USER_ID, ("Manager",))
         document = api.content.create(
             title="Document", id="document", type="Document", container=self.portal
         )

--- a/src/collective/purgebyid/tests/test_purge.py
+++ b/src/collective/purgebyid/tests/test_purge.py
@@ -182,7 +182,9 @@ class TestHelperView(unittest.TestCase):
         @adapter(Interface, IHTTPRequest)
         class CustomDocumentView(BrowserView):
             def __call__(self):
-                mark_involved_objects(self.request, api.content.find(portal_type="Document"))
+                mark_involved_objects(
+                    self.request, api.content.find(portal_type="Document")
+                )
                 return "OK"
 
         # register the view

--- a/tox.ini
+++ b/tox.ini
@@ -13,10 +13,10 @@ skip_install = true
 deps =
     -r requirements-5.2.x.txt
 commands_pre =
-    plone43: {envbindir}/buildout -Nc {toxinidir}/plone-4.3.x.cfg buildout:directory={envdir} buildout:develop={toxinidir}
-    plone50: {envbindir}/buildout -Nc {toxinidir}/plone-5.0.x.cfg buildout:directory={envdir} buildout:develop={toxinidir}
-    plone51: {envbindir}/buildout -Nc {toxinidir}/plone-5.1.x.cfg buildout:directory={envdir} buildout:develop={toxinidir}
-    plone52: {envbindir}/buildout -Nc {toxinidir}/plone-5.2.x.cfg buildout:directory={envdir} buildout:develop={toxinidir}
+    plone43: {envbindir}/buildout -Nc {toxinidir}/plone-4.3.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test coverage
+    plone50: {envbindir}/buildout -Nc {toxinidir}/plone-5.0.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test coverage
+    plone51: {envbindir}/buildout -Nc {toxinidir}/plone-5.1.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test coverage
+    plone52: {envbindir}/buildout -Nc {toxinidir}/plone-5.2.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test coverage
 # changedir={envdir}
 commands =
     {envbindir}/coverage run {envbindir}/test


### PR DESCRIPTION
Improvements ported from collective.xkey

The helper view has been changed from the one in `collective.xkey`, because calling a view that removes cached content should be avoided  to users, due to possible DoS.